### PR TITLE
Fix for searching upper case characters

### DIFF
--- a/src/aha-table.html
+++ b/src/aha-table.html
@@ -555,7 +555,7 @@ pagetext pageoftext pagesizetext summarytext itemoftext
 						|| 
 						// non-empty search and the content matches.
 						row[searchedColumn] 
-						&& row[searchedColumn].toString().indexOf(e.target.value.toString().toLowerCase()) > -1) {
+						&& row[searchedColumn].toString().toLowerCase().indexOf(e.target.value.toString().toLowerCase()) > -1) {
 						matched = true;
 					}
 


### PR DESCRIPTION
Noticed that if the field you're searching in has upper case characters then the search will skip over them.  This happens because your search string is always converted to lower case while the column entry is not.