### PR TITLE
Check if dataset exists before using it

### DIFF
--- a/dist/aha-table.html
+++ b/dist/aha-table.html
@@ -627,7 +627,7 @@
 			if (this.get('meta').length === 0) {
 				this.dataChanged(this.get('data'), []);
 			}
-			if (this.dataset.sizelist) {
+			if (this.dataset && this.dataset.sizelist) {
 				this.sizelist = JSON.parse(this.dataset.sizelist);
 			}
 			//Show element when it's ready.

--- a/src/aha-table.html
+++ b/src/aha-table.html
@@ -627,7 +627,7 @@
 			if (this.get('meta').length === 0) {
 				this.dataChanged(this.get('data'), []);
 			}
-			if (this.dataset.sizelist) {
+			if (this.dataset && this.dataset.sizelist) {
 				this.sizelist = JSON.parse(this.dataset.sizelist);
 			}
 			//Show element when it's ready.


### PR DESCRIPTION
The property dataset is not supported in IE 10, therefore we have to check if it exists before using it.