### PR TITLE
Fixed a small typo in aha-column properties

### DIFF
--- a/src/aha-table.html
+++ b/src/aha-table.html
@@ -1195,7 +1195,7 @@
 				type: Boolean,
 				value: false
 			},
-			requried: {
+			required: {
 				type: Boolean,
 				value: false
 			},


### PR DESCRIPTION
Was preventing setting the required flag to columns. Should now be fixed.